### PR TITLE
Update KeepassXC to 2.7.6

### DIFF
--- a/abi_used_symbols
+++ b/abi_used_symbols
@@ -667,6 +667,7 @@ libQt5Core.so.5:_ZN9QtPrivate15ResultStoreBase9addResultEiPKv
 libQt5Core.so.5:_ZN9QtPrivate16QStringList_joinEPK11QStringListPK5QChari
 libQt5Core.so.5:_ZN9QtPrivate16QStringList_sortEP11QStringListN2Qt15CaseSensitivityE
 libQt5Core.so.5:_ZN9QtPrivate18QStringList_filterEPK11QStringListRK18QRegularExpression
+libQt5Core.so.5:_ZN9QtPrivate18QStringList_filterEPK11QStringListRK7QStringN2Qt15CaseSensitivityE
 libQt5Core.so.5:_ZN9QtPrivate19QStringList_indexOfEPK11QStringListRK18QRegularExpressioni
 libQt5Core.so.5:_ZN9QtPrivate20QContainerImplHelper3midEiPiS1_
 libQt5Core.so.5:_ZN9QtPrivate20QStringList_containsEPK11QStringList13QLatin1StringN2Qt15CaseSensitivityE
@@ -1236,7 +1237,6 @@ libQt5Gui.so.5:_ZN13QStandardItemC1ERK5QIconRK7QString
 libQt5Gui.so.5:_ZN13QStandardItemC1ERK7QString
 libQt5Gui.so.5:_ZN13QTextDocument12setPlainTextERK7QString
 libQt5Gui.so.5:_ZN13QTextDocument17setDocumentMarginEd
-libQt5Gui.so.5:_ZN13QTextDocument18setUndoRedoEnabledEb
 libQt5Gui.so.5:_ZN15QGuiApplication10styleHintsEv
 libQt5Gui.so.5:_ZN15QGuiApplication11focusWindowEv
 libQt5Gui.so.5:_ZN15QGuiApplication11modalWindowEv
@@ -1288,6 +1288,10 @@ libQt5Gui.so.5:_ZN4QPenC1ERKS_
 libQt5Gui.so.5:_ZN4QPenC1Ev
 libQt5Gui.so.5:_ZN4QPenD1Ev
 libQt5Gui.so.5:_ZN4QPenaSERKS_
+libQt5Gui.so.5:_ZN5QDrag11setMimeDataEP9QMimeData
+libQt5Gui.so.5:_ZN5QDrag4execE6QFlagsIN2Qt10DropActionEES2_
+libQt5Gui.so.5:_ZN5QDrag9setPixmapERK7QPixmap
+libQt5Gui.so.5:_ZN5QDragC1EP7QObject
 libQt5Gui.so.5:_ZN5QFont12setPointSizeEi
 libQt5Gui.so.5:_ZN5QFont12setStrikeOutEb
 libQt5Gui.so.5:_ZN5QFont16setLetterSpacingENS_11SpacingTypeEd
@@ -1490,6 +1494,7 @@ libQt5Gui.so.5:_ZNK7QPixmap6heightEv
 libQt5Gui.so.5:_ZNK7QPixmap6isNullEv
 libQt5Gui.so.5:_ZNK7QPixmap8cacheKeyEv
 libQt5Gui.so.5:_ZNK7QPixmapcv8QVariantEv
+libQt5Gui.so.5:_ZNK7QScreen16devicePixelRatioEv
 libQt5Gui.so.5:_ZNK7QScreen17availableGeometryEv
 libQt5Gui.so.5:_ZNK7QWindow8isActiveEv
 libQt5Gui.so.5:_ZNK7QWindow9isVisibleEv
@@ -1681,10 +1686,12 @@ libQt5Widgets.so.5:_ZN11QHeaderView21setSortIndicatorShownEb
 libQt5Widgets.so.5:_ZN11QHeaderView21setStretchLastSectionEb
 libQt5Widgets.so.5:_ZN11QHeaderView26setCascadingSectionResizesEb
 libQt5Widgets.so.5:_ZN11QListWidget10insertItemEiP15QListWidgetItem
+libQt5Widgets.so.5:_ZN11QListWidget10insertItemEiRK7QString
 libQt5Widgets.so.5:_ZN11QListWidget13setCurrentRowEi
 libQt5Widgets.so.5:_ZN11QListWidget13setItemWidgetEP15QListWidgetItemP7QWidget
 libQt5Widgets.so.5:_ZN11QListWidget5clearEv
 libQt5Widgets.so.5:_ZN11QListWidgetC1EP7QWidget
+libQt5Widgets.so.5:_ZN11QListWidgetD1Ev
 libQt5Widgets.so.5:_ZN11QMainWindow10addToolBarEN2Qt11ToolBarAreaEP8QToolBar
 libQt5Widgets.so.5:_ZN11QMainWindow10setMenuBarEP8QMenuBar
 libQt5Widgets.so.5:_ZN11QMainWindow11qt_metacallEN11QMetaObject4CallEiPPv
@@ -2131,6 +2138,7 @@ libQt5Widgets.so.5:_ZN7QTabBar6addTabERK7QString
 libQt5Widgets.so.5:_ZN7QTabBar9removeTabEi
 libQt5Widgets.so.5:_ZN7QTabBarC1EP7QWidget
 libQt5Widgets.so.5:_ZN7QWidget10adjustSizeEv
+libQt5Widgets.so.5:_ZN7QWidget10clearFocusEv
 libQt5Widgets.so.5:_ZN7QWidget10closeEventEP11QCloseEvent
 libQt5Widgets.so.5:_ZN7QWidget10enterEventEP6QEvent
 libQt5Widgets.so.5:_ZN7QWidget10leaveEventEP6QEvent
@@ -2157,6 +2165,7 @@ libQt5Widgets.so.5:_ZN7QWidget12setFixedSizeERK5QSize
 libQt5Widgets.so.5:_ZN7QWidget13dragMoveEventEP14QDragMoveEvent
 libQt5Widgets.so.5:_ZN7QWidget13focusOutEventEP11QFocusEvent
 libQt5Widgets.so.5:_ZN7QWidget13keyPressEventEP9QKeyEvent
+libQt5Widgets.so.5:_ZN7QWidget13setFixedWidthEi
 libQt5Widgets.so.5:_ZN7QWidget13setFocusProxyEPS_
 libQt5Widgets.so.5:_ZN7QWidget13setSizePolicyE11QSizePolicy
 libQt5Widgets.so.5:_ZN7QWidget13setStyleSheetERK7QString
@@ -2183,6 +2192,7 @@ libQt5Widgets.so.5:_ZN7QWidget15setMaximumWidthEi
 libQt5Widgets.so.5:_ZN7QWidget15setMinimumWidthEi
 libQt5Widgets.so.5:_ZN7QWidget16contextMenuEventEP17QContextMenuEvent
 libQt5Widgets.so.5:_ZN7QWidget16inputMethodEventEP17QInputMethodEvent
+libQt5Widgets.so.5:_ZN7QWidget16setMaximumHeightEi
 libQt5Widgets.so.5:_ZN7QWidget16setMinimumHeightEi
 libQt5Widgets.so.5:_ZN7QWidget16staticMetaObjectE
 libQt5Widgets.so.5:_ZN7QWidget17mouseReleaseEventEP11QMouseEvent
@@ -2400,11 +2410,9 @@ libQt5Widgets.so.5:_ZN9QSplitterC1EP7QWidget
 libQt5Widgets.so.5:_ZN9QTextEdit10moveCursorEN11QTextCursor13MoveOperationENS0_8MoveModeE
 libQt5Widgets.so.5:_ZN9QTextEdit11setReadOnlyEb
 libQt5Widgets.so.5:_ZN9QTextEdit12setPlainTextERK7QString
-libQt5Widgets.so.5:_ZN9QTextEdit15setLineWrapModeENS_12LineWrapModeE
 libQt5Widgets.so.5:_ZN9QTextEdit16staticMetaObjectE
 libQt5Widgets.so.5:_ZN9QTextEdit18setTabChangesFocusEb
 libQt5Widgets.so.5:_ZN9QTextEdit19ensureCursorVisibleEv
-libQt5Widgets.so.5:_ZN9QTextEdit7setHtmlERK7QString
 libQt5Widgets.so.5:_ZN9QTextEditC1EP7QWidget
 libQt5Widgets.so.5:_ZN9QTreeView10moveCursorEN17QAbstractItemView12CursorActionE6QFlagsIN2Qt16KeyboardModifierEE
 libQt5Widgets.so.5:_ZN9QTreeView10paintEventEP11QPaintEvent
@@ -2579,6 +2587,7 @@ libQt5Widgets.so.5:_ZNK17QAbstractItemView14selectionModelEv
 libQt5Widgets.so.5:_ZNK17QAbstractItemView14sizeHintForRowEi
 libQt5Widgets.so.5:_ZNK17QAbstractItemView16inputMethodQueryEN2Qt16InputMethodQueryE
 libQt5Widgets.so.5:_ZNK17QAbstractItemView16selectionCommandERK11QModelIndexPK6QEvent
+libQt5Widgets.so.5:_ZNK17QAbstractItemView17defaultDropActionEv
 libQt5Widgets.so.5:_ZNK17QAbstractItemView17selectionBehaviorEv
 libQt5Widgets.so.5:_ZNK17QAbstractItemView17sizeHintForColumnEi
 libQt5Widgets.so.5:_ZNK17QAbstractItemView21dropIndicatorPositionEv

--- a/package.yml
+++ b/package.yml
@@ -1,9 +1,9 @@
 name       : keepassxc
-version    : 2.7.5
-release    : 42
+version    : 2.7.6
+release    : 43
 homepage   : https://keepassxc.org
 source     :
-    - https://github.com/keepassxreboot/keepassxc/releases/download/2.7.5/keepassxc-2.7.5-src.tar.xz : ede24800901816c49569aa4f8bc7180a40cb8b554617fa2a2a2653caac13000c
+    - https://github.com/keepassxreboot/keepassxc/releases/download/2.7.6/keepassxc-2.7.6-src.tar.xz : a58074509fa8e90f152c6247f73e75e126303081f55eedb4ea0cbb6fa980d670
 license    :
     - BSD-2-Clause
     - BSD-3-Clause
@@ -25,7 +25,7 @@ builddeps  :
     - pkgconfig(Qt5X11Extras)
     - pkgconfig(botan-2)
     - pkgconfig(libargon2)
-    - pkgconfig(libgcrypt) 
+    - pkgconfig(libgcrypt)
     - pkgconfig(libpcsclite)
     - pkgconfig(libqrencode)
     - pkgconfig(libusb-1.0)

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -4,7 +4,7 @@
         <Homepage>https://keepassxc.org</Homepage>
         <Packager>
             <Name>Tracey Clark</Name>
-            <Email>traceyc.dev@tlcnet.info</Email>
+            <Email>tracey_dev@tlcnet.info</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>BSD-3-Clause</License>
@@ -95,12 +95,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2023-05-29</Date>
-            <Version>2.7.5</Version>
+        <Update release="43">
+            <Date>2023-09-02</Date>
+            <Version>2.7.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
-            <Email>traceyc.dev@tlcnet.info</Email>
+            <Email>tracey_dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changelog:**

Changes

    - Significant improvement to visual when drag/drop entries
    - Automatically prompt for Quick Unlock when showing unlock dialog
    - Improve colorful lock icon and fix file MIME icon on KDE
    - Ability to search by entry UUID
    - Add challenge-response support for NitroKey 3
    - Auto-Type: Disable entry level Auto-Type when disabled at group/entry
    - Browser: Show warning when adding duplicate URL's to entry
    - Browser: Improve error message when proxy cannot be found

Fixes

    - Fix crash on exit on macOS
    - Fix crash on search if entry doesn't have a group
    - Fix several issues with Quick Unlock
    - Enable save button when not auto-saving non-data changes
    - Several UI/UX fixes
    - Move toolbar back to top of window when disabling movement
    - Browser: Fix handling of expired credentials
    - Windows: Prevent white flicker when launching application
    - Linux: Fix warning message about allow screencapture
    - FdoSecrets: Fix access confirmation dialog showing even when disabled

Full release notes available [here](https://github.com/keepassxreboot/keepassxc/releases)

### Summary

> Info on what this pull request updates/changes/etc

### Test Plan
- Able to launch keepassxc
- Able to load a database, search entries
- Keeshare appears in the settings screen, UI looks good

> Short description on how the package was tested

### Checklist

- [x ] Package was built and tested against unstable
